### PR TITLE
Alpine and Ubuntu image for cbmc-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.dobi
+alpine-dist
+alpine-tmp
+ubuntu-dist
+ubuntu-tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cbmc"]
+	path = cbmc
+	url = https://github.com/diffblue/cbmc.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+
+os: linux
+
+sudo: required
+
+services:
+  - docker
+
+before_install:
+  # Download dobi binary and save it in the current folder
+  - curl -L https://github.com/dnephin/dobi/releases/download/v0.9/dobi-linux >dobi
+  # Make that binary executable
+  - chmod u+x ./dobi
+  # Pull to be sure that we get all git tags
+  - git pull --depth=2000
+
+  - |
+    # If this is PR then CBMC submodule should refer to diffblue/cbmc repository
+    if [[ "${TRAVIS_PULL_REQUEST}" == "true" && \
+      $(git config --get --file=.gitmodules submodule.cbmc.url) != "https://github.com/diffblue/cbmc.git" ]]
+    then
+        echo "This is pull request. Set CBMC submodule URL to diffblue/cbmc repository."
+        echo "git config --file=.gitmodules submodule.cbmc.url https://github.com/diffblue/cbmc.git"
+        exit 1
+    fi
+
+# Build cbmc-builder and try to build & test cbmc in it. Run in parallel for
+# each distro.
+env:
+  - DISTRO="alpine"
+  - DISTRO="ubuntu"
+
+script:
+  - BUILDER_TAG=$(git describe) ./dobi ${DISTRO}-test

--- a/README.md
+++ b/README.md
@@ -1,18 +1,59 @@
-This is the Git repo of the Docker images for building
-[CBMC](https://github.com/diffblue/cbmc) in/for different operating systems.                        
+# CBMC Builder Docker Images [![Build Status](https://travis-ci.org/diffblue/cbmc-builder.svg?branch=master)](https://travis-ci.org/diffblue/cbmc-builder)
 
-To compile `CBMC` source
+This is the Git repo of the Docker images for building
+[CBMC](https://github.com/diffblue/cbmc) in/for different operating systems.
+
+Builders exist for two OS:
+- alpine in [alpine/Dockerfile](alpine/Dockerfile) referenced as
+  `diffblue/cbmc-builder:alpine`,
+  `diffblue/cbmc-builder:alpine-0.0.1`
+- ubuntu in [ubuntu/Dockerfile](ubuntu/Dockerfile) referenced as
+  `diffblue/cbmc-builder:latest`,
+  `diffblue/cbmc-builder:xenial`,
+  `diffblue/cbmc-builder:xenial-0.0.1`
+
+## To compile CBMC source manually
+
+Set path to your cloned CBMC source
 
 ```bash
-CBMC_PATH=~/Workspace/cbmc-git
+CBMC_PATH=~/git/cbmc
+```
+
+To run compilation [instructions](https://github.com/diffblue/cbmc/blob/master/COMPILING)
+in container
+
+```bash
 docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C src minisat2-download
-docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C src libzip-download zlib-download
-docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C src libzip-build
-docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C src -j2
+docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C src -j$(getconf _NPROCESSORS_ONLN)
 ```
 
 To run tests afterwards
 
 ```bash
 docker run --rm -v ${CBMC_PATH}:/cbmc diffblue/cbmc-builder make -C regression test
+```
+
+## To compile CBMC source using *dobi*
+
+Install [dobi](https://github.com/dnephin/dobi/) and add it to your `PATH`.
+
+Enter to folder with `dobi.yml` (root of this repository).
+
+To run all tasks
+
+```bash
+BUILD_TAG=$(git describe) dobi
+```
+
+To run all tests
+
+```bash
+BUILD_TAG=$(git describe) dobi test
+```
+
+Remove all temporary files
+
+```bash
+BUILD_TAG=$(git describe) dobi clean
 ```

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.5
+
+LABEL maintainer="DiffBlue Ltd."
+
+RUN apk add --no-cache gcc g++ make ccache bison flex perl-libwww bash
+
+# Will be mounted to source during run
+WORKDIR /cbmc

--- a/alpine/Dockerfile.distro
+++ b/alpine/Dockerfile.distro
@@ -1,0 +1,7 @@
+FROM alpine:3.5
+
+LABEL maintainer="DiffBlue Ltd."
+
+RUN apk add --no-cache libgcc libstdc++
+
+COPY alpine-dist /usr/bin

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -1,0 +1,203 @@
+#
+# dobi.yaml - resources for building and testing docker images
+#
+
+meta:
+    project: cbmc
+    default: distros
+
+#
+# Mounts
+#
+
+mount=source:
+    bind: ./cbmc/
+    path: /src/cbmc/
+
+## Alpine Mounts
+
+mount=alpine-tmp:
+    bind: ./alpine-tmp
+    path: /tmp/projects
+
+mount=alpine-dist:
+    bind: ./alpine-dist/
+    path: /dist/
+
+## Ubuntu Mounts
+
+mount=ubuntu-tmp:
+    bind: ./ubuntu-tmp
+    path: /tmp/projects
+
+mount=ubuntu-dist:
+    bind: ./ubuntu-dist/
+    path: /dist/
+
+#
+# Images
+#
+
+## Alpine Images
+
+image=alpine-builder:
+    image: diffblue/cbmc-builder
+    context: alpine/
+    dockerfile: Dockerfile
+    tags:
+      - 'alpine'
+      - 'alpine-{env.BUILDER_TAG}'
+
+image=alpine-distro:
+    image: diffblue/cbmc
+    dockerfile: alpine/Dockerfile.distro
+    depends: ["alpine-copy-binaries"]
+    description: "Build the distribution image"
+    tags:
+      - 'alpine'
+      - 'alpine-{env.BUILDER_TAG}'
+
+## Ubuntu Images
+
+image=ubuntu-builder:
+    image: diffblue/cbmc-builder
+    context: ubuntu/
+    dockerfile: Dockerfile
+    tags:
+      - 'latest'
+      - 'xenial'
+      - 'xenial-{env.BUILDER_TAG}'
+
+image=ubuntu-distro:
+    image: diffblue/cbmc
+    dockerfile: ubuntu/Dockerfile.distro
+    depends: ["ubuntu-copy-binaries"]
+    description: "Build the distribution image"
+    tags:
+      - 'latest'
+      - 'xenial'
+      - 'xenial-{env.BUILDER_TAG}'
+
+#
+# Jobs
+#
+
+## Alpine Jobs
+
+job=alpine-copy-src:
+    use: alpine-builder
+    mounts: [source, alpine-tmp]
+    artifact: alpine-tmp/cbmc
+    command: "bash -c \"cp -r /src/cbmc /tmp/projects/\""
+    description: "Copy source to temporary folder."
+
+job=alpine-prebuild:
+    use: alpine-builder
+    depends: ["alpine-copy-src"]
+    mounts: [alpine-tmp]
+    artifact: alpine-tmp/cbmc/minisat-2.2.1
+    command: "bash -c \"make -C /tmp/projects/cbmc/src minisat2-download\""
+    description: "Do make prebuild actions."
+
+job=alpine-build:
+    use: alpine-builder
+    depends: ["alpine-prebuild"]
+    mounts: [alpine-tmp]
+    artifact: alpine-tmp/cbmc/src/cbmc/cbmc
+    command: "bash -c \"make -C /tmp/projects/cbmc/src -j$(getconf _NPROCESSORS_ONLN)\""
+    description: "Do make build."
+
+job=alpine-test:
+    use: alpine-builder
+    depends: ["alpine-build"]
+    mounts: [alpine-tmp]
+    command: "bash -c \"make -C /tmp/projects/cbmc/regression test\""
+    description: "Do make tests."
+
+job=alpine-copy-binaries:
+    use: alpine-builder
+    depends: ["alpine-build"]
+    mounts: [alpine-tmp, alpine-dist]
+    artifact: alpine-dist/bin
+    command: "bash -c \"mkdir -p /dist/bin && cp -r /tmp/projects/cbmc/src/cbmc/cbmc /dist/bin/ && cp -r /tmp/projects/cbmc/src/goto-*/goto-* /dist/bin/ && rm /dist/bin/*.a\""
+    description: "Copy binaries to dist folder."
+
+job=alpine-clean:
+    use: alpine-builder
+    mounts: [alpine-tmp, alpine-dist]
+    command: "bash -c \"rm -rf /tmp/projects/* && rm -rf /dist/*\""
+    description: "Delete temporary files and binaries"
+
+## Ubuntu Jobs
+
+job=ubuntu-copy-src:
+    use: ubuntu-builder
+    mounts: [source, ubuntu-tmp]
+    artifact: ubuntu-tmp/cbmc
+    command: "bash -c \"cp -r /src/cbmc /tmp/projects/\""
+    description: "Copy source to temporary folder."
+
+job=ubuntu-prebuild:
+    use: ubuntu-builder
+    depends: ["ubuntu-copy-src"]
+    mounts: [ubuntu-tmp]
+    artifact: ubuntu-tmp/cbmc/minisat-2.2.1
+    command: "bash -c \"make -C /tmp/projects/cbmc/src minisat2-download\""
+    description: "Do make prebuild actions."
+
+job=ubuntu-build:
+    use: ubuntu-builder
+    depends: ["ubuntu-prebuild"]
+    mounts: [ubuntu-tmp]
+    artifact: ubuntu-tmp/cbmc/src/cbmc/cbmc
+    command: "bash -c \"make -C /tmp/projects/cbmc/src -j$(getconf _NPROCESSORS_ONLN)\""
+    description: "Do make build."
+
+job=ubuntu-test:
+    use: ubuntu-builder
+    depends: ["ubuntu-build"]
+    mounts: [ubuntu-tmp]
+    command: "bash -c \"make -C /tmp/projects/cbmc/regression test\""
+    description: "Do make tests."
+
+job=ubuntu-copy-binaries:
+    use: ubuntu-builder
+    depends: ["ubuntu-build"]
+    mounts: [ubuntu-tmp, ubuntu-dist]
+    artifact: ubuntu-dist/bin
+    command: "bash -c \"mkdir -p /dist/bin && cp -r /tmp/projects/cbmc/src/cbmc/cbmc /dist/bin/ && cp -r /tmp/projects/cbmc/src/goto-*/goto-* /dist/bin/ && rm /dist/bin/*.a\""
+    description: "Copy binaries to dist folder."
+
+job=ubuntu-clean:
+    use: ubuntu-builder
+    mounts: [ubuntu-tmp, ubuntu-dist]
+    command: "bash -c \"rm -rf /tmp/projects/* && rm -rf /dist/*\""
+    description: "Delete temporary files and binaries"
+
+#
+# Aliases
+#
+
+alias=alpine:
+    tasks: [alpine-copy-src, alpine-prebuild, alpine-build, alpine-test, alpine-copy-binaries]
+    description: "Run all containers and jobs for Alpine"
+
+alias=ubuntu:
+    tasks: [ubuntu-copy-src, ubuntu-prebuild, ubuntu-build, ubuntu-test, ubuntu-copy-binaries]
+    description: "Run all containers and jobs for Ubuntu"
+
+alias=test:
+    tasks: [alpine-test, ubuntu-test]
+    description: "Run all tests for all distros."
+
+alias=distros:
+    tasks: [alpine-distro, ubuntu-distro]
+    description: "Create all distro images."
+
+alias=clean:
+    tasks: [alpine-clean, ubuntu-clean]
+    description: "Delete temporary files and binaries for all distros."
+
+alias=all:
+    tasks: [alpine, ubuntu]
+    description: "Run all jobs for all distros."

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+LABEL maintainer="DiffBlue Ltd."
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      g++ gcc make ccache bison flex libwww-perl patch \
+	  && rm -rf /var/lib/apt/lists/*
+
+# Will be mounted to source during run
+WORKDIR /cbmc

--- a/ubuntu/Dockerfile.distro
+++ b/ubuntu/Dockerfile.distro
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+
+LABEL maintainer="DiffBlue Ltd."
+
+COPY ubuntu-dist /usr/bin


### PR DESCRIPTION
`diffblue/cbmc-builder` docker image is used for compilation CBMC in our projects and it should be documented and versioned.
After merge I will create version 0.0.1 which I then reference in out travis builds so we can update builder image, test it and then reference to a newer version.