### PR TITLE
Add git to cbmc-builder

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.5
 
 LABEL maintainer="DiffBlue Ltd."
 
-RUN apk add --no-cache gcc g++ make ccache bison flex perl-libwww bash
+RUN apk add --no-cache gcc g++ make ccache bison flex perl-libwww bash git
 
 # Will be mounted to source during run
 WORKDIR /cbmc

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="DiffBlue Ltd."
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-      g++ gcc make ccache bison flex libwww-perl patch \
+      g++ gcc make ccache bison flex libwww-perl patch git \
 	  && rm -rf /var/lib/apt/lists/*
 
 # Will be mounted to source during run


### PR DESCRIPTION
Required when a version of cbmc it being extracted during build (in https://github.com/diffblue/cbmc/pull/668)